### PR TITLE
GrandOutput.Dispose()/BinaryFile performance fix

### DIFF
--- a/CK.Monitoring/GrandOutputHandlers/BinaryFile.cs
+++ b/CK.Monitoring/GrandOutputHandlers/BinaryFile.cs
@@ -47,7 +47,7 @@ namespace CK.Monitoring.GrandOutputHandlers
         private void OpenFile()
         {
             _openedTimeUtc = DateTime.UtcNow;
-            _output = new FileStream( _path + Guid.NewGuid().ToString() + ".ckmon.tmp", FileMode.CreateNew, FileAccess.Write, FileShare.Read, 8, FileOptions.SequentialScan|FileOptions.WriteThrough );
+            _output = new FileStream( _path + Guid.NewGuid().ToString() + ".ckmon.tmp", FileMode.CreateNew, FileAccess.Write, FileShare.Read, 4096, FileOptions.SequentialScan|FileOptions.WriteThrough );
             _writer = new BinaryWriter( _output );
             _writer.Write( LogReader.CurrentStreamVersion );
         }


### PR DESCRIPTION
Currently, a BinaryFile's [FileStream](http://msdn.microsoft.com/en-us/library/d0y914c5%28v=vs.110%29.aspx) is created with 8 bytes of buffer.

With this, on my current machine, writing 30 000 entries took a whopping 82 minutes and 13 seconds. 

Whoops.

During this time, the hard drive controller is hammered with writes, and obviously GrandOutput's disposal is halted while the BinaryFile isn't flushed away.

Increasing the buffer to FileStream's internal default of 4 KB (4096 bytes, according to Reflector/Decompiler) reduces this time to a mere 67 seconds; still a lot for a 4 MB output, granted, but better. 87 times better here, at least.

I did not notice any more improvement by increasing the buffer beyond 4 KB.

We can reduce this to 16 second if we blindly trust the OS' cache and drop FileOptions.WriteThrough, but I understand we want to keep it.

Update: The tests were mistakingly made using 5 entries per .ckmon file, but the point still applies: using the default (20 000) per file, I went from ~5 minutes (4B) to 2 seconds (4KB). So the 67 seconds I mentioned are... actually justified when you're creating 6 000 new files.
