### PR TITLE
Enabled nullable on a function. + Added build dep.

### DIFF
--- a/CK.Core/CK.Core.csproj
+++ b/CK.Core/CK.Core.csproj
@@ -2,12 +2,18 @@
   <Import Project="..\Common\Shared.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Description>CK.Core contains types and helpers that are used across different projects. Main types are: CKTrait, DateTimeStamp, SimpleServiceContainer, CriticalErrorCollector, FIFOBuffer, TemporaryFile, BestKeeper, SHA1/SHA512Stream and SHA1/SHA512Value.</Description>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CK.Text" Version="9.0.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>

--- a/CK.Core/Extension/DictionaryExtension.cs
+++ b/CK.Core/Extension/DictionaryExtension.cs
@@ -22,7 +22,10 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CK.Core
 {
@@ -31,7 +34,7 @@ namespace CK.Core
     /// </summary>
     public static class DictionaryExtension
     {
-
+#nullable enable
         /// <summary>
         /// Gets the value associated with the specified key if it exists otherwise returns the <paramref name="defaultValue"/>.
         /// </summary>
@@ -41,12 +44,14 @@ namespace CK.Core
         /// <returns>
         /// The value associated with the specified key, if the key is found; otherwise, the <paramref name="defaultValue"/>. 
         /// </returns>
-        public static TValue GetValueWithDefault<TKey, TValue>( this IDictionary<TKey, TValue> @this, TKey key, TValue defaultValue )
+        [return: NotNullIfNotNull( "defaultValue" )]
+        public static TValue? GetValueWithDefault<TKey, TValue>( this IDictionary<TKey, TValue> @this, TKey key, TValue? defaultValue )
         {
             TValue result;
             if( !@this.TryGetValue( key, out result ) ) result = defaultValue;
             return result;
         }
+#nullable disable
 
         /// <summary>
         /// Gets the value associated with the specified key if it exists otherwise calls the <paramref name="defaultValue"/> function.
@@ -58,7 +63,7 @@ namespace CK.Core
         /// The value associated with the specified key, if the key is found; otherwise, the result 
         /// of the <paramref name="defaultValue"/> delegate.
         /// </returns>
-        public static TValue GetValueWithDefaultFunc<TKey, TValue>( this IDictionary<TKey, TValue> @this, TKey key, Func<TKey,TValue> defaultValue )
+        public static TValue GetValueWithDefaultFunc<TKey, TValue>( this IDictionary<TKey, TValue> @this, TKey key, Func<TKey, TValue> defaultValue )
         {
             TValue result;
             if( !@this.TryGetValue( key, out result ) ) result = defaultValue( key );


### PR DESCRIPTION
I annotated a function.  
Most notably, I added a build-dep (TunnelVisionLabs.ReferenceAssemblyAnnotator).

The annotated function itself use an Attribute target, something I didn't know existed:  
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/attributes/#attribute-targets
It allows to annotate the getter, setter, and the return value of a function.

A similar function exists but takes a Func as input, I don't know if it can be annotated properly but if it can it would be a nice hard exercise in nullable annotation.