### PR TITLE
Provide char overloads for Concatenate extensions :

### DIFF
--- a/CK.Core/Extension/StringAndStringBuilderExtension.cs
+++ b/CK.Core/Extension/StringAndStringBuilderExtension.cs
@@ -33,6 +33,29 @@ namespace CK.Core
         public static string Concatenate( this IEnumerable<string?> @this, char separator ) => String.Join( separator, @this );
 
         /// <summary>
+        /// Concatenates multiple chars with an internal separator.
+        /// </summary>
+        /// <param name="this">Set of chars.</param>
+        /// <param name="separator">The separator string.</param>
+        /// <returns>The joined string.</returns>
+        public static string Concatenate( this IEnumerable<char> @this, string separator ) => String.Join( separator, @this );
+
+        /// <summary>
+        /// Concatenates multiple chars without any internal separator.
+        /// </summary>
+        /// <param name="this">Set of chars.</param>
+        /// <returns>The joined string.</returns>
+        public static string Concatenate( this IEnumerable<char> @this ) => @this.Concatenate( string.Empty );
+
+        /// <summary>
+        /// Concatenates multiple chars with an internal character separator.
+        /// </summary>
+        /// <param name="this">Set of chars.</param>
+        /// <param name="separator">The separator character.</param>
+        /// <returns>The joined string.</returns>
+        public static string Concatenate( this IEnumerable<char> @this, char separator ) => String.Join( separator, @this );
+
+        /// <summary>
         /// Appends a set of strings with an internal separator.
         /// (This should be named 'Append' but appropriate overload is not always detected by the compiler.)
         /// </summary>
@@ -94,9 +117,9 @@ namespace CK.Core
 
         /// <summary>
         /// Appends a block of text to this StringBuilder with a prefix on each line.
-        /// <c>b.AppendMultiLine( prefix, text, false, true )</c> is the same as the naive approach, 
+        /// <c>b.AppendMultiLine( prefix, text, false, true )</c> is the same as the naive approach,
         /// that is to add <c>text.Replace( Environment.NewLine, Environment.NewLine + prefix )</c>.
-        /// This method is faster (in release build), normalizes EOL (\n, \r and \r\n) 
+        /// This method is faster (in release build), normalizes EOL (\n, \r and \r\n)
         /// to <see cref="Environment.NewLine"/> and offer a better and easier control with its
         /// parameters <paramref name="prefixOnFirstLine"/> and <paramref name="prefixLastEmptyLine"/>.
         /// </summary>

--- a/Tests/CK.Core.Tests/StringAndStringBuilderExtensionTests.cs
+++ b/Tests/CK.Core.Tests/StringAndStringBuilderExtensionTests.cs
@@ -17,6 +17,30 @@ namespace CK.Core.Tests
         }
 
         [Test]
+        public void concat_method_uses_String_Join_inside_char_overload()
+        {
+            var chars = new[] { 'A', 'H', 'B', 'W', ' ', 'E' };
+            var s = chars.Concatenate( "|+|" );
+            s.Should().Be( "A|+|H|+|B|+|W|+| |+|E" );
+        }
+
+        [Test]
+        public void concat_method_uses_String_Join_inside_char_overload_no_separator()
+        {
+            var chars = new[] { 'A', 'H', 'B', 'W', ' ', 'E' };
+            var s = chars.Concatenate();
+            s.Should().Be( "AHBW E" );
+        }
+
+        [Test]
+        public void concat_method_uses_String_Join_inside_char_overload_char_separator()
+        {
+            var chars = new[] { 'A', 'H', 'B', 'W', ' ', 'E' };
+            var s = chars.Concatenate(',');
+            s.Should().Be( "A,H,B,W, ,E" );
+        }
+
+        [Test]
         public void StringBuilder_AppendStrings_method_does_not_skip_null_entries()
         {
             var strings = new string[] { "A", "Hello", "B", "World", null!, "End" };
@@ -147,8 +171,8 @@ Second line.
 
     Also indented.
 Last line.";
-                // Here, normalizing the source embedded string is to support 
-                // git clone with LF in files instead of CRLF. 
+                // Here, normalizing the source embedded string is to support
+                // git clone with LF in files instead of CRLF.
                 // Our AppendMultiLine normalizes the end of lines to Environment.NewLine.
                 string t = b.AppendMultiLine( "|", text, true ).ToString();
                 t.Should().Be( @"|First line.


### PR DESCRIPTION
It does make not sense imho to overload with IEnumerable<char?>, while IEnumerable<char> is a comfortable tool to have. I created an extra overload without separator to prevent using a default value "". Instead, I can call string.Empty.

There is no default separator, usually when concatenating an array of char, I assume the caller want to craft again a word or a phrase that got either truncated or manipulated in some way.separator.